### PR TITLE
Fix Flutter blank screen

### DIFF
--- a/fpfa_app/lib/main.dart
+++ b/fpfa_app/lib/main.dart
@@ -2,6 +2,8 @@ import "dart:math";
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'package:flutter/foundation.dart'
+    show kIsWeb, defaultTargetPlatform, TargetPlatform;
 
 void main() {
   runApp(const MyApp());
@@ -185,8 +187,12 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadArticles() async {
     try {
+      final baseUrl = (!kIsWeb &&
+              defaultTargetPlatform == TargetPlatform.android)
+          ? 'http://10.0.2.2:5000'
+          : 'http://localhost:5000';
       final response = await http.get(
-        Uri.parse('http://localhost:5000/api/articles'),
+        Uri.parse('$baseUrl/api/articles'),
       );
       if (response.statusCode == 200) {
         final List<dynamic> data = json.decode(response.body);
@@ -227,7 +233,9 @@ class _HomePageState extends State<HomePage> {
         child: Center(
           child: loading
               ? const CircularProgressIndicator()
-              : Deck(key: _deckKey, articles: articles),
+              : articles.isEmpty
+                  ? const Text('No articles found')
+                  : Deck(key: _deckKey, articles: articles),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- use proper base URL for the Flutter API client
- show a message if no articles are loaded

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: fixture 'headers' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543b7e7580832aaae753429446025c