### PR TITLE
Fix API accessibility for Flutter app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 from flask import Flask, render_template, jsonify
+from flask_cors import CORS
 import sqlite3
 
 app = Flask(__name__)
+CORS(app)
 
 def get_latest_articles(limit=10):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ Werkzeug==3.1.3
 wsproto==1.2.0
 playwright
 playwright-stealth
+Flask-Cors==4.0.0

--- a/test_scraping_methods.py
+++ b/test_scraping_methods.py
@@ -1,6 +1,20 @@
 import requests
 from bs4 import BeautifulSoup
 import time
+import pytest
+
+
+@pytest.fixture
+def headers():
+    return {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    }
+
+
+@pytest.fixture
+def cookies():
+    return {}
 
 def test_with_headers(headers):
     url = "https://www.foreignaffairs.com/most-recent"
@@ -126,3 +140,4 @@ if __name__ == "__main__":
     test_with_cookies(headers3, cookies)
     print("\nTest 5: Selenium headless browser")
     test_with_selenium()
+


### PR DESCRIPTION
## Summary
- enable CORS in the Flask backend
- pin `Flask-Cors` in requirements
- provide fixtures so Python tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543fa29e34832a88e06e0070e0d828