### PR TITLE
Fix Flutter API URL via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Foreign Policy & Foreign Affairs Summaries
+
+This repository contains a small Flask backend that serves article summaries from `articles.db` and a Flutter front-end (`fpfa_app`) that displays them.
+
+## Running the backend
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+The API will be available at `http://localhost:5000/api/articles` by default.
+
+## Running the Flutter app
+
+From the `fpfa_app` directory, run `flutter run`. The app expects the backend URL specified by the `API_BASE_URL` compile-time environment variable. If none is supplied, it defaults to `http://localhost:5000` (or `http://10.0.2.2:5000` when running on the Android emulator).
+
+Example:
+
+```bash
+flutter run -d chrome --dart-define=API_BASE_URL=http://192.168.1.100:5000
+```

--- a/fpfa_app/lib/main.dart
+++ b/fpfa_app/lib/main.dart
@@ -188,10 +188,12 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadArticles() async {
     try {
-      final baseUrl = (!kIsWeb &&
+      final defaultUrl = (!kIsWeb &&
               defaultTargetPlatform == TargetPlatform.android)
           ? 'http://10.0.2.2:5000'
           : 'http://localhost:5000';
+      const envUrl = String.fromEnvironment('API_BASE_URL');
+      final baseUrl = envUrl.isNotEmpty ? envUrl : defaultUrl;
       final response = await http.get(
         Uri.parse('$baseUrl/api/articles'),
       );


### PR DESCRIPTION
## Summary
- allow override of the API base URL via `API_BASE_URL`
- document backend and front-end usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685542d1bd94832aa2d7eff922a52d13