### PR TITLE
Add API endpoint test and README troubleshooting tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ Example:
 ```bash
 flutter run -d chrome --dart-define=API_BASE_URL=http://192.168.1.100:5000
 ```
+
+## Troubleshooting
+If the Flutter app displays **"Failed to load articles"**, confirm the backend is reachable and that the app is using the correct API URL.
+
+1. Start the Flask server (from this directory):
+   ```bash
+   pip install -r requirements.txt
+   python app.py
+   ```
+2. Verify the endpoint returns data:
+   ```bash
+   curl http://localhost:5000/api/articles | head
+   ```
+   You should see JSON output.
+3. Run the Flutter app with an explicit API URL (adjust if the server runs elsewhere):
+   ```bash
+   flutter run -d edge --dart-define=API_BASE_URL=http://localhost:5000
+   ```
+4. Ensure `articles.db` exists in the project root so the backend can read the database.
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,10 @@
+import requests
+
+BASE_URL = 'http://localhost:5000'
+
+def test_api_articles():
+    response = requests.get(f'{BASE_URL}/api/articles')
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0


### PR DESCRIPTION
## Summary
- add `tests/test_api.py` to verify `api/articles` returns data
- document common Flutter API errors in README

## Testing
- `pytest -q tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685546e5842c832a986f7021d4c45e2e