### PR TITLE
Separate FPFA into its dedicated Google Cloud project

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "pressreview-458312"
+    "default": "ppf-fpfa-summary-prod"
   }
 }

--- a/.github/workflows/deploy_android.yml
+++ b/.github/workflows/deploy_android.yml
@@ -8,11 +8,24 @@ on:
       - '.github/workflows/deploy_android.yml'
   workflow_dispatch:
 
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'ppf-fpfa-summary-prod' }}
+  FIREBASE_ANDROID_APP_ID: ${{ vars.FIREBASE_ANDROID_APP_ID || '1:1076204999548:android:d3d96617e2156818764af9' }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -33,9 +46,14 @@ jobs:
         run: flutter build apk --release
         working-directory: fpfa_app
 
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools
+
       - name: Upload to Firebase App Distribution
-        uses: w9jds/firebase-action@master
-        with:
-          args: appdistribution:distribute fpfa_app/build/app/outputs/flutter-apk/app-release.apk --app 1:1028212947283:android:295bda3d6c89668cd549a6 --groups "testers"
-        env:
-          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: >-
+          firebase appdistribution:distribute
+          fpfa_app/build/app/outputs/flutter-apk/app-release.apk
+          --app "${FIREBASE_ANDROID_APP_ID}"
+          --groups "testers"
+          --project "${GCP_PROJECT_ID}"
+          --non-interactive

--- a/.github/workflows/deploy_flutter_static_web_apps.yml
+++ b/.github/workflows/deploy_flutter_static_web_apps.yml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  API_BASE_URL_PROD: ${{ vars.API_BASE_URL_PROD || 'https://fpfa-summary-api-1028212947283.europe-west1.run.app' }}
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'ppf-fpfa-summary-prod' }}
+  API_BASE_URL_PROD: ${{ vars.API_BASE_URL_PROD || 'https://fpfa-summary-api-1076204999548.europe-west1.run.app' }}
 
 jobs:
   test-web:
@@ -47,9 +48,18 @@ jobs:
     needs: test-web
     environment:
       name: Production
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -66,9 +76,8 @@ jobs:
         run: flutter build web --dart-define=API_BASE_URL=${API_BASE_URL_PROD}
         working-directory: fpfa_app
 
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools
+
       - name: Deploy to Firebase Hosting
-        uses: w9jds/firebase-action@master
-        with:
-          args: deploy --only hosting
-        env:
-          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: firebase deploy --project "${GCP_PROJECT_ID}" --only hosting --non-interactive

--- a/.github/workflows/master_ppfflaskapp.yml
+++ b/.github/workflows/master_ppfflaskapp.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${GCP_BACKEND_SERVICE}:${GITHUB_SHA}"
           echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
-          gcloud builds submit --tag "${IMAGE}"
+          gcloud builds submit --tag "${IMAGE}" --suppress-logs
 
       - name: Deploy to Cloud Run
         id: deploy

--- a/.github/workflows/master_ppfflaskapp.yml
+++ b/.github/workflows/master_ppfflaskapp.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 env:
-  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'pressreview-458312' }}
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'ppf-fpfa-summary-prod' }}
   GCP_REGION: ${{ vars.GCP_REGION || 'europe-west1' }}
   GCP_BACKEND_SERVICE: ${{ vars.GCP_BACKEND_SERVICE || 'fpfa-summary-api' }}
   GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_ARTIFACT_REPOSITORY || 'fpfa' }}
@@ -95,7 +95,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -125,6 +126,7 @@ jobs:
             --image "${IMAGE}" \
             --platform managed \
             --region "${GCP_REGION}" \
+            --service-account "${{ vars.GCP_RUNTIME_SERVICE_ACCOUNT }}" \
             --allow-unauthenticated \
             --min-instances 0 \
             --max-instances 1 \

--- a/.github/workflows/master_ppfflaskapp.yml
+++ b/.github/workflows/master_ppfflaskapp.yml
@@ -117,7 +117,9 @@ jobs:
         run: |
           IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${GCP_BACKEND_SERVICE}:${GITHUB_SHA}"
           echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
-          gcloud builds submit --tag "${IMAGE}" --suppress-logs
+          gcloud builds submit \
+            --tag "${IMAGE}" \
+            --gcs-log-dir="gs://ppf-fpfa-summary-prod-cloudbuild-logs"
 
       - name: Deploy to Cloud Run
         id: deploy

--- a/.github/workflows/update_articles.yml
+++ b/.github/workflows/update_articles.yml
@@ -1,6 +1,7 @@
 name: Update articles
 permissions:
   contents: read
+  id-token: write
 
 on:
   schedule:
@@ -8,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'pressreview-458312' }}
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'ppf-fpfa-summary-prod' }}
   ARTICLES_COLLECTION: ${{ vars.ARTICLES_COLLECTION || 'articles' }}
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       ARTICLE_STORE: firestore
-      FIRESTORE_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'pressreview-458312' }}
+      FIRESTORE_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'ppf-fpfa-summary-prod' }}
       ARTICLES_COLLECTION: ${{ vars.ARTICLES_COLLECTION || 'articles' }}
 
     steps:
@@ -27,7 +28,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_INGEST_SERVICE_ACCOUNT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ python summarize_fp.py 7
 Required environment for real summarization:
 
 ```bash
-export GEMINI_API_KEY=your_key_here
+export FPFA_GEMINI_API_KEY=your_key_here
 ```
 
 Firestore target:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -173,7 +173,7 @@ curl http://localhost:8000/api/articles
 ### Validate ingestion against Firestore
 
 ```bash
-export GEMINI_API_KEY=...
+export FPFA_GEMINI_API_KEY=...
 export ARTICLE_STORE=firestore
 export FIRESTORE_PROJECT_ID=pressreview-458312
 python summarize_fa_hardened.py 1

--- a/fpfa_app/android/app/google-services.json
+++ b/fpfa_app/android/app/google-services.json
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "1028212947283",
-    "project_id": "pressreview-458312",
-    "storage_bucket": "pressreview-458312.firebasestorage.app"
+    "project_number": "1076204999548",
+    "project_id": "ppf-fpfa-summary-prod",
+    "storage_bucket": "ppf-fpfa-summary-prod.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:1028212947283:android:295bda3d6c89668cd549a6",
+        "mobilesdk_app_id": "1:1076204999548:android:d3d96617e2156818764af9",
         "android_client_info": {
           "package_name": "com.example.fpfa_app"
         }
@@ -15,26 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyBud9kk9EttCkmaT2QoaDQGSW3l5DA44eU"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": []
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:1028212947283:android:832c9e3bf7c2d34dd549a6",
-        "android_client_info": {
-          "package_name": "com.example.myapp"
-        }
-      },
-      "oauth_client": [],
-      "api_key": [
-        {
-          "current_key": "AIzaSyBud9kk9EttCkmaT2QoaDQGSW3l5DA44eU"
+          "current_key": "AIzaSyCRa3SeB0KUDONCY1rfgdzzmmIYA-920T0"
         }
       ],
       "services": {

--- a/summarize_fa_hardened.py
+++ b/summarize_fa_hardened.py
@@ -286,9 +286,9 @@ def main():
         sys.exit(1)
 
     # 2. Summarise
-    api_key = os.environ.get("GEMINI_API_KEY")
+    api_key = os.environ.get("FPFA_GEMINI_API_KEY") or os.environ.get("GEMINI_API_KEY")
     if not api_key:
-        print("[ERROR] GEMINI_API_KEY env var not set.")
+        print("[ERROR] FPFA_GEMINI_API_KEY env var not set.")
         sys.exit(1)
     client = create_client(api_key)
 

--- a/summarize_fp.py
+++ b/summarize_fp.py
@@ -423,10 +423,10 @@ def main():
             f"out of requested {num_articles_to_summarize}."
         )
 
-    api_key = os.environ.get("GEMINI_API_KEY")
+    api_key = os.environ.get("FPFA_GEMINI_API_KEY") or os.environ.get("GEMINI_API_KEY")
     if not api_key:
-        print("Error: GEMINI_API_KEY environment variable not set.")
-        print("Please set your Gemini API key as an environment variable named GEMINI_API_KEY.")
+        print("Error: FPFA_GEMINI_API_KEY environment variable not set.")
+        print("GEMINI_API_KEY remains supported only for cloud deployment compatibility.")
         sys.exit(1)
 
     client = create_client(api_key)


### PR DESCRIPTION
Moves FPFA deployment, ingestion, Firebase Hosting and Android distribution to ppf-fpfa-summary-prod. Replaces the shared service-account JSON with GitHub OIDC identities and points the runtime at the dedicated Firestore database and Cloud Run service.